### PR TITLE
feat: ensured that prevalues and datasources are actually usync compatible

### DIFF
--- a/uSync.Forms.Site/uSync/v9/Forms-PreValues/test.config
+++ b/uSync.Forms.Site/uSync/v9/Forms-PreValues/test.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<PreValue Key="93b8dfeb-8123-4fcd-bd21-ca0948ca4ba1" Alias="test123">
+  <Info>
+    <Name>test</Name>
+    <FieldPreValueSourceTypeId>35c2053e-cbf7-4793-b27c-6e97b7671a2d</FieldPreValueSourceTypeId>
+  </Info>
+  <Settings>{
+  "TextFile": "PreValueTextFiles\\8a4f4f9b-f2c7-4ff9-92aa-7177f6c121b2\\test.txt"
+}</Settings>
+  <TextFile>
+    <FileContent>[{"id":"0","value":"test","caption":"","sortOrder":0},{"id":"1","value":"tes2","caption":"","sortOrder":1},{"id":"2","value":"test3","caption":"","sortOrder":2}]</FileContent>
+  </TextFile>
+</PreValue>

--- a/uSync.Forms/Dependencies/FormPreValuesDependencyChecker.cs
+++ b/uSync.Forms/Dependencies/FormPreValuesDependencyChecker.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Models;
+
+using uSync.Core.Dependency;
+
+using static Umbraco.Cms.Core.Constants;
+using Constants = Umbraco.Cms.Core.Constants;
+
+namespace uSync.Forms.Dependencies
+{
+    public class FormPreValuesDependencyChecker : ISyncDependencyChecker<FieldPreValueSource>
+    {
+        public UmbracoObjectTypes ObjectType => UmbracoObjectTypes.FormsPreValue;
+
+        public IEnumerable<uSyncDependency> GetDependencies(FieldPreValueSource item, DependencyFlags flags)
+        {
+            if (item == null) return Enumerable.Empty<uSyncDependency>();
+
+            var items = new List<uSyncDependency>
+            {
+                new uSyncDependency
+                {
+                    Flags = flags,
+                    Level = 100,
+                    Mode = DependencyMode.MustExist,
+                    Name = item.Name,
+                    Order = 1,
+                    Udi = Udi.Create(Constants.UdiEntityType.FormsPreValue, item.Id)
+                }
+            };
+            return items;
+        }
+
+        
+    }
+}

--- a/uSync.Forms/Dependencies/FormsDataSourceDependencyChecker.cs
+++ b/uSync.Forms/Dependencies/FormsDataSourceDependencyChecker.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Extensions;
+using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Models;
+
+using uSync.Core.Dependency;
+
+using static Umbraco.Cms.Core.Constants;
+using Constants = Umbraco.Cms.Core.Constants;
+
+namespace uSync.Forms.Dependencies
+{
+    public class FormsDataSourceDependencyChecker : ISyncDependencyChecker<FormDataSource>
+    {
+        public UmbracoObjectTypes ObjectType => UmbracoObjectTypes.FormsDataSource;
+
+        public IEnumerable<uSyncDependency> GetDependencies(FormDataSource item, DependencyFlags flags)
+        {
+            if (item == null) return Enumerable.Empty<uSyncDependency>();
+
+            var items = new List<uSyncDependency>
+            {
+                new uSyncDependency
+                {
+                    Flags = flags,
+                    Level = 100,
+                    Mode = DependencyMode.MustExist,
+                    Name = item.Name,
+                    Order = 1,
+                    Udi = Udi.Create(Constants.UdiEntityType.FormsDataSource, item.Id)
+                }
+            };
+            return items;
+        }
+
+        
+    }
+}

--- a/uSync.Forms/Mappers/FormPickerValueMapper.cs
+++ b/uSync.Forms/Mappers/FormPickerValueMapper.cs
@@ -42,13 +42,23 @@ namespace uSync.Forms.Mappers
 
                     if (form != null)
                     {
-                        return new uSyncDependency
+                        var formDependency = new uSyncDependency
                         {
                             Name = form.Name,
                             Udi = Udi.Create(UdiEntityType.FormsForm, form.Id),
                             Flags = flags,
-                            Order = uSyncFormPriorities.Forms
-                        }.AsEnumerableOfOne();
+                            Order = uSyncFormPriorities.Forms,
+                        }.AsEnumerableOfOne().ToList();
+                        if (form.DataSource == null)
+                        {
+                            return formDependency;
+                        }
+                        formDependency.Add(new uSyncDependency
+                        {
+                            Udi = Udi.Create(UdiEntityType.FormsDataSource, form.DataSource.Id),
+                            Flags = flags,
+                            Order = uSyncFormPriorities.DataSources,
+                        });
                     }
                 }
             }

--- a/uSync.Forms/Serializers/PreValueSerializer.cs
+++ b/uSync.Forms/Serializers/PreValueSerializer.cs
@@ -2,14 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml.Linq;
-
 using Microsoft.Extensions.Logging;
-
 using Newtonsoft.Json;
-
 using Umbraco.Forms.Core;
+using Umbraco.Forms.Core.Data;
+using Umbraco.Forms.Core.Models;
 using Umbraco.Forms.Core.Providers;
-
+using Umbraco.Forms.Core.Services;
 using uSync.Core;
 using uSync.Core.Models;
 using uSync.Core.Serialization;
@@ -24,14 +23,17 @@ namespace uSync.Forms.Serializers
 
         private readonly SyncFormService _syncFormService;
         private readonly FieldPreValueSourceCollection _fieldPreValueSourceTypes;
+        private readonly IPreValueTextFileStorage _preValueTextFileStorage;
 
         public PreValueSerializer(
             SyncFormService syncFormService,
             FormsMapperHelper formsMapperHelper,
             FieldPreValueSourceCollection fieldPreValueSourceTypes,
+            IPreValueTextFileStorage preValueTextFileStorage,
             ILogger<PreValueSerializer> logger) : base(logger)
         {
             _fieldPreValueSourceTypes = fieldPreValueSourceTypes;
+            _preValueTextFileStorage = preValueTextFileStorage;
             _syncFormService = syncFormService;
             _mapperHelper = formsMapperHelper;
         }
@@ -44,25 +46,48 @@ namespace uSync.Forms.Serializers
 
 
             var info = new XElement("Info",
-                new XElement ("Name", item.Name),
-                new XElement ("FieldPreValueSourceTypeId", item.FieldPreValueSourceTypeId));
+                new XElement("Name", item.Name),
+                new XElement("FieldPreValueSourceTypeId", item.FieldPreValueSourceTypeId));
 
             node.Add(info);
 
             var settingsJson = JsonConvert.SerializeObject(MapExportSettings(item.Settings), Formatting.Indented);
             node.Add(new XElement("Settings", settingsJson));
+            if (item.Settings.ContainsKey("TextFile") /*  todo: figure out if we want it conditionally && options.GetSetting("IncludeFileContent", false) */)
+            {
+                node.Add(new XElement("TextFile", SerializeFileContent(item.Settings["TextFile"])));
+            }
 
             return SyncAttempt<XElement>.Succeed(item.Name, node, ChangeType.Export, []);
         }
 
-        protected override SyncAttempt<FieldPreValueSource> DeserializeCore(XElement node, SyncSerializerOptions options)
+        private XElement SerializeFileContent(string item)
         {
-
-            var item = FindItem(node) 
-                ?? new FieldPreValueSource
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(item))
                 {
-                    Id = node.GetKey()
-                };
+                    return new XElement("FileContent",
+                        JsonConvert.SerializeObject(_preValueTextFileStorage.GetTextFilePreValues(item)));
+                }
+            }
+            catch (Exception ex)
+            {
+                // can happen when the media locations get moved.
+                logger.LogError(ex, "Error reading prevalueSource file: {item}", item);
+            }
+
+            return new XElement("FileContent", "");
+        }
+
+        protected override SyncAttempt<FieldPreValueSource> DeserializeCore(XElement node,
+            SyncSerializerOptions options)
+        {
+            var item = FindItem(node)
+                       ?? new FieldPreValueSource
+                       {
+                           Id = node.GetKey()
+                       };
 
             var info = node.Element("Info");
             if (info != null)
@@ -80,10 +105,22 @@ namespace uSync.Forms.Serializers
             }
 
             var settings = node.Element("Settings").ValueOrDefault(string.Empty);
-            if (!string.IsNullOrWhiteSpace(settings)) {
+            if (!string.IsNullOrWhiteSpace(settings))
+            {
                 item.Settings = MapImportSettings(JsonConvert.DeserializeObject<Dictionary<string, string>>(settings));
             }
-            
+            var textFile = node.Element("TextFile");
+            if (textFile != null)
+            {
+                var textFileContent = textFile.Element("FileContent").ValueOrDefault(string.Empty);
+                if (!string.IsNullOrWhiteSpace(textFileContent))
+                {
+                    var preValues = JsonConvert.DeserializeObject<List<PreValue>>(textFileContent);
+                    var textFileName = item.Settings["TextFile"];
+                    _preValueTextFileStorage.SaveValuesIntoFile(preValues.Select(x=>$"{x.Value}|{x.Caption}").ToList(),textFileName);
+                }
+            }
+
             return SyncAttempt<FieldPreValueSource>.Succeed(item.Name, item, ChangeType.Import, []);
         }
 
@@ -91,8 +128,8 @@ namespace uSync.Forms.Serializers
         {
             // for export we copy the directory so we have no chance of 
             // accidently altering the form data. 
-            var mapped = new Dictionary<string,string>(settings);
-            foreach(var key in mapped.Keys.ToList())
+            var mapped = new Dictionary<string, string>(settings);
+            foreach (var key in mapped.Keys.ToList())
             {
                 mapped[key] = _mapperHelper.GetExportValue(mapped[key]);
             }
@@ -104,10 +141,11 @@ namespace uSync.Forms.Serializers
         {
             // for an import we created this directory from the XElement, we don't 
             // need to copy it. 
-            foreach(var key in settings.Keys.ToList())
+            foreach (var key in settings.Keys.ToList())
             {
                 settings[key] = _mapperHelper.GetImportValue(settings[key]);
             }
+
             return settings;
         }
 

--- a/uSync.Forms/Serializers/PreValueSerializer.cs
+++ b/uSync.Forms/Serializers/PreValueSerializer.cs
@@ -53,7 +53,7 @@ namespace uSync.Forms.Serializers
 
             var settingsJson = JsonConvert.SerializeObject(MapExportSettings(item.Settings), Formatting.Indented);
             node.Add(new XElement("Settings", settingsJson));
-            if (item.Settings.ContainsKey("TextFile") /*  todo: figure out if we want it conditionally && options.GetSetting("IncludeFileContent", false) */)
+            if (item.Settings.ContainsKey("TextFile") && options.GetSetting("IncludeFileContent", true))
             {
                 node.Add(new XElement("TextFile", SerializeFileContent(item.Settings["TextFile"])));
             }

--- a/uSync.Forms/Sync/FormDataSourcesSyncManager.cs
+++ b/uSync.Forms/Sync/FormDataSourcesSyncManager.cs
@@ -1,0 +1,121 @@
+﻿using Microsoft.Extensions.Logging;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core;
+
+using uSync.Core.Dependency;
+using uSync.Core.Sync;
+using uSync.Forms.Services;
+
+using static Umbraco.Cms.Core.Constants;
+
+namespace uSync.Forms.Sync
+{
+    /// <summary>
+    ///  form Sync manager, tells uSync.Complete how to render the push/pull menus.
+    /// </summary>
+    [SyncItemManager(UdiEntityType.FormsDataSource, Umbraco.Forms.Core.Constants.Trees.DataSource)]
+    public class FormDataSourcesSyncManager : SyncItemManagerBase, ISyncItemManager
+    {
+        private readonly SyncFormService _formService;
+        private readonly ILogger<FormSyncManager> _logger;
+
+        public FormDataSourcesSyncManager(SyncFormService formService, ILogger<FormSyncManager> logger)
+        {
+            _logger = logger;
+            _formService = formService;
+        }
+
+        public override string[] EntityTypes => new string[]
+        {
+            UdiEntityType.FormsDataSource
+        };
+
+
+        /////////////////        
+        // Forms doesn't use the EditorService to open its picker (because why would it)
+        // but if it did then we could do this, and then forms would also appear in 
+        // uSyncExporter so they could be included in export sync packs. 
+
+        //public override SyncEntityInfo GetSyncInfo(string entityType)
+        //{
+        //    return new SyncEntityInfo
+        //    {
+        //        SectionAlias = Constants.Applications.Forms,
+        //        TreeAlias = Umbraco.Forms.Core.Constants.Trees.Form,
+        //        PickerView = "/App_Plugins/UmbracoForms/Backoffice/Form/overlays/formpicker/formpicker.html"
+        //    };
+        //}
+
+        public SyncLocalItem GetEntity(SyncTreeItem treeItem)
+        {
+            if (treeItem.Id == Constants.System.RootString)
+                return GetRootItem(treeItem);
+            if (!Guid.TryParse(treeItem.Id, out Guid formKey)) return null;
+
+            var form = _formService.GetDataSource(formKey);
+            if (form == null) return null;
+
+            return new SyncLocalItem
+            {
+                EntityType = EntityType,
+                Id = treeItem.Id,
+                Name = form.Name,
+                Udi = Udi.Create(EntityType, form.Id)
+            };
+        }
+
+        public override IEnumerable<SyncItem> GetItems(SyncItem item)
+        {
+            var items = new List<SyncItem>();
+
+            if (item.Udi.EntityType == UdiEntityType.FormsDataSource)
+            {
+                // we only add orginal item if its a form, we don't sync empty folders.
+                items.Add(item);
+            }
+            return items;            
+        }
+
+        protected override IEnumerable<SyncItem> GetDecendants(SyncItem item, DependencyFlags flags)
+        {
+            if (item.Udi.IsRoot)
+            {
+                return _formService.GetAllForms().Select(x => new SyncItem
+                {
+                    Name = x.Name,
+                    Udi = Udi.Create(UdiEntityType.FormsForm, x.Id),
+                    Flags = flags & ~DependencyFlags.IncludeChildren
+                });
+            }
+            else
+            {
+                switch(item.Udi.EntityType)
+                {
+                    case UdiEntityType.FormsPreValue:
+                        return Enumerable.Empty<SyncItem>();
+                    case uSyncForms.FolderEntityType:
+                        if (item.Udi is GuidUdi guidUdi) {
+                            var forms = _formService.GetFolderForms(guidUdi.Guid)
+                                .Select(x => new SyncItem
+                                {
+                                    Name = x.Name,
+                                    Udi = Udi.Create(UdiEntityType.FormsForm, x.Id),
+                                    Flags = flags & ~DependencyFlags.IncludeChildren
+                                });
+
+                            _logger.LogDebug("Getting Forms in folder: {guid} {count}", guidUdi, forms.Count());
+
+                            return forms;
+                        }
+                        break;
+                }
+            }
+
+            return Enumerable.Empty<SyncItem>();
+        }
+    }
+}

--- a/uSync.Forms/Sync/FormPreValuesSyncManager.cs
+++ b/uSync.Forms/Sync/FormPreValuesSyncManager.cs
@@ -1,0 +1,122 @@
+﻿using Microsoft.Extensions.Logging;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Umbraco.Cms.Core;
+
+using uSync.Core.Dependency;
+using uSync.Core.Sync;
+using uSync.Forms.Services;
+
+using static Umbraco.Cms.Core.Constants;
+
+namespace uSync.Forms.Sync
+{
+    /// <summary>
+    ///  form Sync manager, tells uSync.Complete how to render the push/pull menus.
+    /// </summary>
+    [SyncItemManager(UdiEntityType.FormsPreValue, Umbraco.Forms.Core.Constants.Trees.PreValueSource)]
+    public class FormPreValuesSyncManager : SyncItemManagerBase, ISyncItemManager
+    {
+        private readonly SyncFormService _formService;
+        private readonly ILogger<FormSyncManager> _logger;
+
+        public FormPreValuesSyncManager(SyncFormService formService, ILogger<FormSyncManager> logger)
+        {
+            _logger = logger;
+            _formService = formService;
+        }
+
+        public override string[] EntityTypes => new string[]
+        {
+            UdiEntityType.FormsPreValue
+        };
+
+
+        /////////////////        
+        // Forms doesn't use the EditorService to open its picker (because why would it)
+        // but if it did then we could do this, and then forms would also appear in 
+        // uSyncExporter so they could be included in export sync packs. 
+
+        //public override SyncEntityInfo GetSyncInfo(string entityType)
+        //{
+        //    return new SyncEntityInfo
+        //    {
+        //        SectionAlias = Constants.Applications.Forms,
+        //        TreeAlias = Umbraco.Forms.Core.Constants.Trees.Form,
+        //        PickerView = "/App_Plugins/UmbracoForms/Backoffice/Form/overlays/formpicker/formpicker.html"
+        //    };
+        //}
+
+        public SyncLocalItem GetEntity(SyncTreeItem treeItem)
+        {
+            if (treeItem.Id == Constants.System.RootString)
+                return GetRootItem(treeItem);
+
+            if (!Guid.TryParse(treeItem.Id, out Guid formKey)) return null;
+
+            var form = _formService.GetPreValueSource(formKey);
+            if (form == null) return null;
+
+            return new SyncLocalItem
+            {
+                EntityType = EntityType,
+                Id = treeItem.Id,
+                Name = form.Name,
+                Udi = Udi.Create(EntityType, form.Id)
+            };
+        }
+
+        public override IEnumerable<SyncItem> GetItems(SyncItem item)
+        {
+            var items = new List<SyncItem>();
+
+            if (item.Udi.EntityType == UdiEntityType.FormsPreValue)
+            {
+                // we only add orginal item if its a form, we don't sync empty folders.
+                items.Add(item);
+            }
+            return items;            
+        }
+
+        protected override IEnumerable<SyncItem> GetDecendants(SyncItem item, DependencyFlags flags)
+        {
+            if (item.Udi.IsRoot)
+            {
+                return _formService.GetAllForms().Select(x => new SyncItem
+                {
+                    Name = x.Name,
+                    Udi = Udi.Create(UdiEntityType.FormsForm, x.Id),
+                    Flags = flags & ~DependencyFlags.IncludeChildren
+                });
+            }
+            else
+            {
+                switch(item.Udi.EntityType)
+                {
+                    case UdiEntityType.FormsPreValue:
+                        return Enumerable.Empty<SyncItem>();
+                    case uSyncForms.FolderEntityType:
+                        if (item.Udi is GuidUdi guidUdi) {
+                            var forms = _formService.GetFolderForms(guidUdi.Guid)
+                                .Select(x => new SyncItem
+                                {
+                                    Name = x.Name,
+                                    Udi = Udi.Create(UdiEntityType.FormsForm, x.Id),
+                                    Flags = flags & ~DependencyFlags.IncludeChildren
+                                });
+
+                            _logger.LogDebug("Getting Forms in folder: {guid} {count}", guidUdi, forms.Count());
+
+                            return forms;
+                        }
+                        break;
+                }
+            }
+
+            return Enumerable.Empty<SyncItem>();
+        }
+    }
+}


### PR DESCRIPTION
This pr resolve this issue: https://github.com/KevinJump/uSync.Forms/issues/15
I actually tested it with both normal usync, usync exporter and usync complete.

The thing to discuss with you @KevinJump, do we want make Prevalue files conditional? Imho it is required for them to work at all and display forms so it shouldn't be conditional, what you think?