### PR TITLE
Fix - #14 - make sure message stays as html

### DIFF
--- a/uSync.Forms.Site/uSync/v9/Forms/test-form.config
+++ b/uSync.Forms.Site/uSync/v9/Forms/test-form.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<forms-form Key="2dcf205c-28bd-4409-b4f0-6aadce808740" Alias="Test Form">
+<forms-form Key="cfd53d45-b300-4980-a792-4148aa092911" Alias="Test Form">
   <Info>
     <Name>Test Form</Name>
     <FieldIndicationType>NoIndicator</FieldIndicationType>
@@ -8,7 +8,7 @@
     <HideFieldValidation>false</HideFieldValidation>
     <RequireErrorMessage>Please provide a value for {0}</RequireErrorMessage>
     <InvalidErrorMessage>Please provide a valid value for {0}</InvalidErrorMessage>
-    <MessageOnSubmit>Thank you</MessageOnSubmit>
+    <MessageOnSubmit IsHtml="true">&lt;p&gt;Thank you&lt;/p&gt;</MessageOnSubmit>
     <GoToPageOnSubmit>00000000-0000-0000-0000-000000000000</GoToPageOnSubmit>
     <XPathOnSubmit></XPathOnSubmit>
     <ManualApproval>false</ManualApproval>
@@ -18,7 +18,7 @@
     <AutocompleteAttribute></AutocompleteAttribute>
     <Workflows>
       <Workflow>
-        <Id>13b8f2dd-a9ca-4994-83f1-c96b5f6d8804</Id>
+        <Id>f606ade4-24db-4504-b2f4-2778b13d2ffc</Id>
         <Name>Send template email to kevin@thejumps.co.uk</Name>
         <Active>true</Active>
         <IncludeSensitiveData>False</IncludeSensitiveData>
@@ -51,7 +51,7 @@
       {
         "caption": null,
         "sortOrder": 0,
-        "id": "6fb8f6ac-fafc-46f3-9b67-fc31b191db96",
+        "id": "4e27aa9f-b08f-4b31-a011-f8253309e85b",
         "page": "00000000-0000-0000-0000-000000000000",
         "containers": [
           {
@@ -64,7 +64,7 @@
                 "placeholder": null,
                 "cssClass": null,
                 "alias": "dataConsent",
-                "id": "757218e2-7e14-4fd9-85a9-4e1912c5c7e0",
+                "id": "163e5b6e-caa2-4e03-a255-0ecf7cc5c116",
                 "fieldTypeId": "a72c9df9-3847-47cf-afb8-b86773fd12cd",
                 "prevalueSourceId": "00000000-0000-0000-0000-000000000000",
                 "dataSourceFieldKey": null,
@@ -88,9 +88,9 @@
         "condition": null
       }
     ],
-    "caption": null,
+    "caption": "test",
     "sortOrder": 0,
-    "id": "c18c62cd-7d70-4300-a600-0504e0c1c834",
+    "id": "4dce57ae-0ea3-4e2f-a394-023ccd1c05a5",
     "form": "00000000-0000-0000-0000-000000000000",
     "buttonCondition": null
   }

--- a/uSync.Forms/Serializers/FormSerializer.cs
+++ b/uSync.Forms/Serializers/FormSerializer.cs
@@ -53,7 +53,8 @@ namespace uSync.Forms.Serializers
             info.Add(new XElement("HideFieldValidation", item.HideFieldValidation));
             info.Add(new XElement("RequireErrorMessage", item.RequiredErrorMessage));
             info.Add(new XElement("InvalidErrorMessage", item.InvalidErrorMessage));
-            info.Add(new XElement("MessageOnSubmit", item.MessageOnSubmit));
+            info.Add(new XElement("MessageOnSubmit", item.MessageOnSubmit,
+                new XAttribute("IsHtml", item.MessageOnSubmitIsHtml)));
 
             info.Add(new XElement("GoToPageOnSubmit", GetContentKey(item.GoToPageOnSubmit)));
 
@@ -235,6 +236,7 @@ namespace uSync.Forms.Serializers
             item.RequiredErrorMessage = info.Element("RequireErrorMessage").ValueOrDefault(string.Empty);
             item.InvalidErrorMessage = info.Element("InvalidErrorMessage").ValueOrDefault(string.Empty);
             item.MessageOnSubmit = info.Element("MessageOnSubmit").ValueOrDefault(string.Empty);
+            item.MessageOnSubmitIsHtml = info.Element("MessageOnSubmit")?.Attribute("IsHtml").ValueOrDefault(false) ?? false;
 
             item.GoToPageOnSubmit = GetContentId(info.Element("GoToPageOnSubmit").ValueOrDefault(Guid.Empty));
 


### PR DESCRIPTION
fixes the issue, we were not serializing the `MessageOnSubmitIsHtml` value 

after this patch the exports will include an IsHtml attribute on the value 

```xml
    <MessageOnSubmit IsHtml="true">&lt;p&gt;Thank you&lt;/p&gt;</MessageOnSubmit>
```

and this will be read when importing 